### PR TITLE
#44 add article about "Set default file upload provider as Cloudinary"

### DIFF
--- a/articles/articles.yml
+++ b/articles/articles.yml
@@ -1,0 +1,8 @@
+- title: Set default file upload provider as Cloudinary
+  url: https://medium.com/@kwinten.yc.li/strapi-set-default-file-upload-provider-to-s3-cloudinary-rackspace-5b8ef6f61daa
+  source: https://medium.com/
+  description: Programmatically set the default file upload provider in different environment, this article talks about Cloudinary specifically as an example
+  categories:
+    - Feature
+  written_by: Kwinten Li
+  written_by_url: https://github.com/kwinyyyc


### PR DESCRIPTION
Submitting an article about "Set default file upload provider as Cloudinary".


As there is no record currently in the yaml file, please let me know if the way I am adding to the yaml file is correct, will adjust accordingly if needed. Thanks!