### PR TITLE
Fix typo on tutorials video title

### DIFF
--- a/tutorials/tutorials.yml
+++ b/tutorials/tutorials.yml
@@ -1206,7 +1206,7 @@
     - strapi
     - content type
   version: beta
-- title: Why I like Strapo
+- title: Why I like Strapi
   link: https://www.youtube.com/watch?v=EBqRR8-Hd84
   formats:
     - video


### PR DESCRIPTION
Hey guys, just a small typo that I found while I was looking at the new website, btw, huge congrats, it's beautiful! =D

Follow the image with the typo:

![image](https://user-images.githubusercontent.com/3991845/82377027-66deb800-99f9-11ea-9ba0-6f8d29524508.png)
