### PR TITLE
Fix the wrong path and script in README

### DIFF
--- a/tutorials/code/angular-strapi-apollo-blog/README.md
+++ b/tutorials/code/angular-strapi-apollo-blog/README.md
@@ -8,5 +8,5 @@ This example is the result of the tutorial series [Build a blog with Angular.js,
 To see it live:
 
 - Clone the repository.
-- Start the Strapi server: `cd tutorials/angular-strapi-apollo-blog/backend && yarn && strapi dev`.
-- Start the angular server: `cd tutorials/angular-strapi-apollo-blog/frontend && yarn && ng serve`.
+- Start the Strapi server: `cd tutorials/code/angular-strapi-apollo-blog/backend && yarn && strapi dev`.
+- Start the angular server: `cd tutorials/code/angular-strapi-apollo-blog/frontend && yarn && ng serve`.

--- a/tutorials/code/deliveroo-clone-next-strapi-tutorial/README.md
+++ b/tutorials/code/deliveroo-clone-next-strapi-tutorial/README.md
@@ -7,5 +7,5 @@ This example is the result of the tutorial series "[Cooking a Deliveroo clone wi
 To see it live:
 
 - Clone the repository.
-- Start the Strapi server: `cd tutorials/deliveroo-clone-next-strapi-tutorial/backend && yarn && strapi dev`.
-- In an other tab, start the nextjs server: `cd tutorials/deliveroo-clone-next-strapi-tutorial/frontend && yarn && yarn dev`.
+- Start the Strapi server: `cd tutorials/code/deliveroo-clone-next-strapi-tutorial/backend && yarn && strapi dev`.
+- In an other tab, start the nextjs server: `cd tutorials/code/deliveroo-clone-next-strapi-tutorial/frontend && yarn && yarn dev`.

--- a/tutorials/code/deliveroo-clone-next-strapi-tutorial/backend/README.md
+++ b/tutorials/code/deliveroo-clone-next-strapi-tutorial/backend/README.md
@@ -8,7 +8,7 @@ $ yarn
 
 ### Run the server
 ```bash
-$ yarn dev
+$ yarn develop
 ```
 
 ### build for production and launch server

--- a/tutorials/code/deliveroo-clone-nuxt-strapi-tutorial/README.md
+++ b/tutorials/code/deliveroo-clone-nuxt-strapi-tutorial/README.md
@@ -7,5 +7,5 @@ This example is the result of the tutorial series "[Cooking a Deliveroo clone wi
 To see it live:
 
 - Clone the repository.
-- Start the Strapi server: `cd tutorials/deliveroo-clone-nuxt-strapi-tutorial/backend && yarn && strapi dev`.
-- In an other tab, start the nextjs server: `cd tutorials/deliveroo-clone-nuxt-strapi-tutorial/frontend && yarn && yarn dev`.
+- Start the Strapi server: `cd tutorials/code/deliveroo-clone-nuxt-strapi-tutorial/backend && yarn && strapi dev`.
+- In an other tab, start the nextjs server: `cd tutorials/code/deliveroo-clone-nuxt-strapi-tutorial/frontend && yarn && yarn dev`.

--- a/tutorials/code/gatsby-strapi-static-blog/README.md
+++ b/tutorials/code/gatsby-strapi-static-blog/README.md
@@ -8,5 +8,5 @@ This example is the result of the tutorial series [Build a static blog with Gats
 To see it live:
 
 - Clone the repository.
-- Start the Strapi server: `cd tutorials/gatsby-strapi-static-blog/backend && yarn && strapi dev`.
-- Start the Gatsby server: `cd tutorials/gatsby-strapi-static-blog/frontend && yarn && Gatsby develop`.
+- Start the Strapi server: `cd tutorials/code/gatsby-strapi-static-blog/backend && yarn && strapi dev`.
+- Start the Gatsby server: `cd tutorials/code/gatsby-strapi-static-blog/frontend && yarn && Gatsby develop`.

--- a/tutorials/code/next-strapi-apollo-blog/README.md
+++ b/tutorials/code/next-strapi-apollo-blog/README.md
@@ -8,5 +8,5 @@ This example is the result of the tutorial series [Build a blog with Next.js, St
 To see it live:
 
 - Clone the repository.
-- Start the Strapi server: `cd tutorials/next-strapi-apollo-blog/backend && yarn && strapi dev`.
-- Start the Next server: `cd tutorials/next-strapi-apollo-blog/frontend && yarn && yarn dev`.
+- Start the Strapi server: `cd tutorials/code/next-strapi-apollo-blog/backend && yarn && strapi dev`.
+- Start the Next server: `cd tutorials/code/next-strapi-apollo-blog/frontend && yarn && yarn dev`.

--- a/tutorials/code/nuxt-strapi-apollo-blog/README.md
+++ b/tutorials/code/nuxt-strapi-apollo-blog/README.md
@@ -8,5 +8,5 @@ This example is the result of the tutorial series [Build a blog with Nuxt, Strap
 To see it live:
 
 - Clone the repository.
-- Start the Strapi server: `cd tutorials/nuxt-strapi-apollo-blog/backend && yarn && strapi dev`.
-- Start the Nuxt server: `cd tutorials/nuxt-strapi-apollo-blog/frontend && yarn && yarn dev`.
+- Start the Strapi server: `cd tutorials/code/nuxt-strapi-apollo-blog/backend && yarn && strapi dev`.
+- Start the Nuxt server: `cd tutorials/code/nuxt-strapi-apollo-blog/frontend && yarn && yarn dev`.

--- a/tutorials/code/react-strapi-apollo-blog/README.md
+++ b/tutorials/code/react-strapi-apollo-blog/README.md
@@ -8,5 +8,5 @@ This example is the result of the tutorial series [Build a blog with React, Stra
 To see it live:
 
 - Clone the repository.
-- Start the Strapi server: `cd tutorials/react-strapi-apollo-blog/backend && yarn && strapi dev`.
-- Start the Next server: `cd tutorials/react-strapi-apollo-blog/frontend && yarn && yarn start`.
+- Start the Strapi server: `cd tutorials/code/react-strapi-apollo-blog/backend && yarn && strapi dev`.
+- Start the Next server: `cd tutorials/code/react-strapi-apollo-blog/frontend && yarn && yarn start`.


### PR DESCRIPTION
## Description

- Fix multiple README that misses `/code` in the path
  - Example: `tutorials/angular-strapi-apollo-blog/backend ` to `tutorials/code/angular-strapi-apollo-blog/backend `
- Fix the wrong script in the `tutorials/code/deliveroo-clone-next-strapi-tutorial/backend`'s README
  - Change `yarn dev` to `yarn develop` according to the script in it's `package.json`